### PR TITLE
Fix issue with mocking abstract classes

### DIFF
--- a/Z_MOCKA/CLAS/ZCL_MOCKA_MOCKER.slnk
+++ b/Z_MOCKA/CLAS/ZCL_MOCKA_MOCKER.slnk
@@ -147,7 +147,7 @@
         IF lo_mocker_method IS NOT INITIAL.
           lv_generate_method = lo_mocker_method-&gt;has_registered_call_pattern( ).
         ENDIF.
-        IF lv_generate_method = abap_false.
+        IF lv_generate_method = abap_false and <ls_method>-is_abstract eq abap_false.
           CONTINUE.
         ELSE.
           lv_code_redefinition = &apos;REDEFINITION&apos;.
@@ -189,7 +189,7 @@
       IF lo_mocker_method IS NOT INITIAL.
         lv_generate_method = lo_mocker_method-&gt;has_registered_call_pattern( ).
       ENDIF.
-      IF lv_generate_method = abap_false.
+      IF lv_generate_method = abap_false and <ls_method>-is_abstract eq abap_false.
         CONTINUE.
       ENDIF.
     ENDIF.


### PR DESCRIPTION
When mocking an abstract class, if you don't mock all the abstract methods explicitly you get an error saying that a subclass of an abstract class must implement all the abstract methods of the super class. This gets around that issue by redefining any methods that are abstract even if they don't have registered call patterns.